### PR TITLE
[Feat] RequestHandler, Router 기능추가

### DIFF
--- a/include/CGI/CgiHandler.hpp
+++ b/include/CGI/CgiHandler.hpp
@@ -15,5 +15,5 @@ public:
 	CgiHandler(Kqueue& kqueue, CgiExecuter& cgiExecuter);
 	~CgiHandler();
 	
-	void handleRequest(const Request& request, int clientFd);
+	void handleCgiRequest(const Request& request, int clientFd);
 };

--- a/include/CGI/CgiHandler.hpp
+++ b/include/CGI/CgiHandler.hpp
@@ -6,14 +6,14 @@
 
 class CgiHandler {
 private:
-	Kqueue& kqueue_;
-	CgiExecuter& cgiExecuter_;
-	
-	std::string requestTypeToString(RequestType type);
+    Kqueue& kqueue_;
+    CgiExecuter cgiExecuter_;
+
+    std::string requestTypeToString(RequestType type);
 
 public:
-	CgiHandler(Kqueue& kqueue, CgiExecuter& cgiExecuter);
-	~CgiHandler();
-	
-	void handleCgiRequest(const Request& request, int clientFd);
+    CgiHandler(Kqueue& kqueue);
+    ~CgiHandler();
+
+    void handleCgiRequest(const Request& request, int clientFd);
 };

--- a/include/request_handler/RequestHandler.hpp
+++ b/include/request_handler/RequestHandler.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Router.hpp"
+#include "Request.hpp"
+#include "Response.hpp"
+#include "CgiHandler.hpp"
+#include "CgiExecuter.hpp"
+// #include "StaticResourceHandler.hpp"
+
+class RequestHandler {
+private:
+    Router router_;
+    CgiHandler cgiHandler_;   // ✅ `CgiHandler` 추가
+    // StaticResourceHandler staticHandler_;
+
+public:
+    RequestHandler(Kqueue& kqueue);
+    ~RequestHandler();
+
+    void handleRequest(const Request& request, int clientFd);
+};

--- a/include/request_handler/Router.hpp
+++ b/include/request_handler/Router.hpp
@@ -1,0 +1,20 @@
+#ifndef ROUTER_HPP
+# define ROUTER_HPP
+
+#include <string>
+#include <map>
+
+class Router {
+private:
+    std::map<std::string, std::string> routes;
+
+public:
+    Router();
+    ~Router();
+
+    void addRoute(const std::string& path, const std::string& handlerType);
+    std::string getHandlerType(const std::string& path) const;
+};
+
+
+#endif

--- a/include/request_parser/RequestParser.hpp
+++ b/include/request_parser/RequestParser.hpp
@@ -1,0 +1,49 @@
+#ifndef REQUEST_PARSER_HPP
+# define REQUEST_PARSER_HPP
+
+# include <sstream>
+# include <tuple>
+# include <string>
+# include "Request.hpp"
+
+class Request; 
+
+
+struct HeaderResult {
+	std::string host;
+	int port;
+	std::string connection;
+	size_t contentLength;
+	std::string accept;
+	std::string contentType;
+};
+
+struct UriComponents {
+	std::string path;
+	std::string query;
+	std::string filename;
+	std::string extension;
+};
+
+struct HeaderValues {
+	std::string host;
+	int port;
+	std::string connection;
+	size_t contentLength;
+	std::string accept;
+	std::string contentType;
+};
+
+
+class RequestParser {
+private:
+	static HeaderResult parseHeaders(std::istringstream& stream);
+	static std::string parseBody(std::istringstream& stream, size_t contentLength);
+	
+public:
+	static Request parseRequestHeader(const std::string& originalRequest);
+	static UriComponents parseUri(const std::string& target);
+
+};
+
+#endif

--- a/include/webserver/MimeTypes.hpp
+++ b/include/webserver/MimeTypes.hpp
@@ -1,0 +1,13 @@
+#ifndef MIME_TYPES_H
+#define MIME_TYPES_H
+
+#include <map>
+#include <string>
+
+// MIME 타입 목록 정의
+extern std::map<std::string, std::string> mimeTypes;
+
+// 확장자로 MIME 타입을 가져오는 함수
+std::string getContentType(const std::string& fileExtension);
+
+#endif

--- a/src/CGI/CgiHandler.cpp
+++ b/src/CGI/CgiHandler.cpp
@@ -16,7 +16,7 @@ std::string CgiHandler::requestTypeToString(RequestType type) {
     }
 }
 
-void CgiHandler::handleRequest(const Request& request, int clientFd) {
+void CgiHandler::handleCgiRequest(const Request& request, int clientFd) {
     std::string requestMethod = requestTypeToString(request.getRequestType());
 
     int outputFd = cgiExecuter_.executeCgiScript(request.getPath(), request.getQuery(), requestMethod, request.getBody());

--- a/src/CGI/CgiHandler.cpp
+++ b/src/CGI/CgiHandler.cpp
@@ -2,7 +2,7 @@
 
 CgiHandler::~CgiHandler() {}
 
-CgiHandler::CgiHandler(Kqueue& kqueue, CgiExecuter& cgiExecuter) : kqueue_(kqueue), cgiExecuter_(cgiExecuter) {}
+CgiHandler::CgiHandler(Kqueue& kqueue) : kqueue_(kqueue), cgiExecuter_() {}
 
 std::string CgiHandler::requestTypeToString(RequestType type) {
     switch (type) {

--- a/src/request_handler/RequestHandler.cpp
+++ b/src/request_handler/RequestHandler.cpp
@@ -1,0 +1,22 @@
+#include "RequestHandler.hpp"
+
+RequestHandler::RequestHandler(Kqueue& kqueue) 
+    : cgiHandler_(kqueue) {
+    router_.addRoute("/cgi-bin/", "CGI");
+    router_.addRoute("/static/", "Static");
+}
+
+RequestHandler::~RequestHandler() {}
+
+void RequestHandler::handleRequest(const Request& request, int clientFd) {
+    std::string handlerType = router_.getHandlerType(request.getPath());
+
+    if (handlerType == "CGI") {
+        cgiHandler_.handleCgiRequest(request, clientFd);
+    } else if (handlerType == "Static") {
+        // Todo: Implement static resource handler
+        // Ex) staticHandler_.serveStaticResource(request.getPath(), clientFd);
+    } else {
+        // Todo: Implement 404 handler
+    }
+}

--- a/src/request_handler/Router.cpp
+++ b/src/request_handler/Router.cpp
@@ -1,0 +1,19 @@
+#include "Router.hpp"
+
+Router::Router() {}
+
+Router::~Router() {}
+
+void Router::addRoute(const std::string& path, const std::string& handlerType) {
+    routes[path] = handlerType;
+}
+
+std::string Router::getHandlerType(const std::string& path) const {
+    std::map<std::string, std::string>::const_iterator it = routes.begin();
+    for (it; it != routes.end(); it++) {
+        if (path.find(it->first) == 0) {
+            return it->second;
+        }
+    }
+    return "Unknown"; // 둘다 아닌경우
+}


### PR DESCRIPTION
# RequestHandler
- cgiHandler를 통한 cgi 요청처리 기능을 구현했습니다.
- staticResourceHandler와 에러페이지는 주석처리 Todo로 일단 남겨 놓았습니다.

# Router
- 경로 처리 기능을 구현했습니다.

# CgiHandler
- 이전의 CgiHandler에서는 cgiExecuter를 주입받아야 했지만, 이를 제거함으로써, RequestHandler에서 cgi실행을 담당해서 SRP를 해치는 일이 없도록 만들었습니다.
- CgiHandler에 있는 handleRequest 함수명 -> handleCgiRequest
  - RequestHandler의 handleRequest 함수의 혼동우려